### PR TITLE
Fixed UnicodeEncodeError in AddFavourite View.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,10 @@ Changelog
 3.1 (unreleased)
 ----------------
 
+- Fixed UnicodeEncodeError in AddFavourite, wich happens when
+  adding a Dexterity Item with a non-ascii title to the Favourites.
+  [phgross]
+
 - Replace jq by $.
   [mathias.leimgruber]
 

--- a/ftw/dashboard/portlets/favourites/browser/favourite.py
+++ b/ftw/dashboard/portlets/favourites/browser/favourite.py
@@ -44,9 +44,12 @@ class AddFavourite(BrowserView):
             self.context.portal_url.getRelativeUrl(self.context),
             )
 
+        title = self.context.title_or_id()
+        if not isinstance(title, unicode):
+            title = title.decode('utf-8')
         msg = _(
             u'${title} has been added to your Favourites.',
-            mapping={u'title': self.context.title_or_id().decode('utf-8')})
+            mapping={u'title': title})
 
         utils.addPortalMessage(msg)
 


### PR DESCRIPTION
Wich happens when adding a Dexterity Item with a non-ascii title to the Favourites.

@jone
