### PR TITLE
Reworked link creation

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,7 +6,9 @@ Changelog
 3.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fixed link creation for users without `Modify portal content` permission
+  on the favouritefolder.
+  [phgross]
 
 
 3.1 (2013-04-16)
@@ -97,4 +99,3 @@ Changelog
 ---
 
 - Initial release
-

--- a/ftw/dashboard/portlets/favourites/adapter.py
+++ b/ftw/dashboard/portlets/favourites/adapter.py
@@ -43,15 +43,12 @@ class DefaultFavouritesHandler(object):
         """ Add favourite to the favourites folder
         """
         folder = self.get_favourites_folder()
-        folder.invokeFactory(
-            'Link',
-            id=fav_id,
-            title=title,
-            remote_url=remote_url)
-
+        folder.invokeFactory('Link', id=fav_id)
         favourite = folder.get(fav_id)
-        favourite.reindexObject()
 
+        favourite.setRemoteUrl(remote_url)
+        favourite.setTitle(title)
+        favourite.reindexObject()
         return favourite
 
     def remove_favourite(self, fav_id):

--- a/ftw/dashboard/portlets/favourites/tests/test_integration.py
+++ b/ftw/dashboard/portlets/favourites/tests/test_integration.py
@@ -40,6 +40,8 @@ class FavouriteTests(TestCase):
         content = self.home['Favourites'].listFolderContents()
 
         self.assertTrue(len(content) == 2)
+        self.assertEquals('Test Folder', content[1].title)
+        self.assertEquals('test_folder', content[1].remote_url())
 
         # Ordering
         links = [link.id for link in content]


### PR DESCRIPTION
For users without `Modify portal content` permission on the favouritefolder, the actual implementation of the favourite creation is not working. It doesn't update the title and the remote_url field. Therefore I reworked the link creation, which solve this problem.

@jone or @lukasgraf: could you take a look?
