### PR TITLE
Added CSRF protection with plone.protect.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,15 @@
-
 *.egg-info
 *.mo
 *.pyc
+.installed.cfg
+.mr.developer.cfg
+bin/
+build/
+buildout.cfg
+coverage/
+develop-eggs/
+dist/
+eggs/
+parts/
+src/
+var/

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,9 @@ Changelog
 3.2.1 (unreleased)
 ------------------
 
+- Added CSRF protection with plone.protect.
+  [phgross]
+
 - Adjust javascript to fix plone 4.1 and 4.2 compatibility.
   [phgross]
 

--- a/ftw/dashboard/portlets/favourites/browser/resources/favourite.js
+++ b/ftw/dashboard/portlets/favourites/browser/resources/favourite.js
@@ -1,5 +1,6 @@
 jQuery(function($) {
 
+  var authenticator_token = $('.portlet.favourite-listing').data('authenticator-token');
   var favouriteId;
   var $titleInputField;
   var $favouriteContainer;
@@ -65,7 +66,10 @@ jQuery(function($) {
     var removeResponse = $.ajax({
       type: 'POST',
       url: './remove_from_favourites',
-      data: 'uid=' + $record.attr("id")
+      data: 'uid=' + $record.attr("id"),
+      beforeSend: function (request){
+        request.setRequestHeader("X-CSRF-TOKEN", authenticator_token);
+      }
     });
     $record.hide().remove();
   };
@@ -75,6 +79,9 @@ jQuery(function($) {
 
     $.ajax({
       url: window.location.href,
+      beforeSend: function (request){
+        request.setRequestHeader("X-CSRF-TOKEN", authenticator_token);
+      },
       success: function(data) {
         $favouriteContainer.empty().html($('#' + favouriteId, data).html());
         makeFavouritesEditable($favouriteContainer);
@@ -94,6 +101,9 @@ jQuery(function($) {
       type: 'POST',
       url: './rename_favourite',
       data: 'uid=' + favouriteId + '&title=' + $titleInputField.val(),
+      beforeSend: function (request){
+        request.setRequestHeader("X-CSRF-TOKEN", authenticator_token);
+      },
       success: function() {
         reloadFavourite();
       },
@@ -176,7 +186,10 @@ jQuery(function($) {
     $.ajax({
       type: 'POST',
       url: './@@reorder_favourites',
-      data: customSerialization(this)
+      data: customSerialization(this),
+      beforeSend: function (request){
+        request.setRequestHeader("X-CSRF-TOKEN", authenticator_token);
+      }
     });
   };
 

--- a/ftw/dashboard/portlets/favourites/portlets/favourites.py
+++ b/ftw/dashboard/portlets/favourites/portlets/favourites.py
@@ -1,14 +1,23 @@
 from ftw.dashboard.portlets.favourites import favouriteMessageFactory as _
+from ftw.dashboard.portlets.favourites.interfaces import IFavouritesHandler
 from plone.app.portlets.browser.formhelper import NullAddForm
 from plone.app.portlets.cache import render_cachekey
 from plone.app.portlets.portlets import base
 from plone.memoize.compress import xhtml_compress
 from plone.portlets.interfaces import IPortletDataProvider
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
-from zope.interface import implements
 from Products.statusmessages.interfaces import IStatusMessage
 from zope.component import getMultiAdapter
-from ftw.dashboard.portlets.favourites.interfaces import IFavouritesHandler
+from zope.interface import implements
+
+
+# Try to get the plone.protect's createToken method, because it's only
+# available since version 2.0.2, otherwise we just use a mocked method.
+try:
+    from plone.protect import createToken
+except ImportError:
+    def createToken():
+        return ''
 
 
 class IFavouritePortlet(IPortletDataProvider):
@@ -42,6 +51,9 @@ class Renderer(base.Renderer):
 
     def render(self):
         return xhtml_compress(self._template())
+
+    def authenticator_token(self):
+        return createToken()
 
 
 class AddForm(NullAddForm):

--- a/ftw/dashboard/portlets/favourites/portlets/templates/favourites.pt
+++ b/ftw/dashboard/portlets/favourites/portlets/templates/favourites.pt
@@ -1,4 +1,5 @@
 <dl class="portlet favourite-listing" i18n:domain="ftw.dashboard.portlets.favourites"
+    tal:attributes="data-authenticator-token view/authenticator_token"
     tal:define="items view/items">
 
     <dt class="portletHeader clearfix">
@@ -36,4 +37,3 @@
     </dd>
 
 </dl>
-


### PR DESCRIPTION
:warning: depends on #16 please merge that one first ... 

The CSRF protection will only work if plone.protect is in the version 2.0.2 or higher (see https://github.com/plone/plone.protect/blob/2.0.2/plone/protect/__init__.py#L5 for more details).

@lukasgraf  @jone 