### PR TITLE
Made Add to Favourites action CSRF safe.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,7 +6,8 @@ Changelog
 3.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Made Add to Favourites action CSRF safe.
+  [phgross]
 
 
 3.3.0 (2015-04-13)

--- a/ftw/dashboard/portlets/favourites/browser/configure.zcml
+++ b/ftw/dashboard/portlets/favourites/browser/configure.zcml
@@ -21,6 +21,7 @@
         name="add_to_favourites"
         permission="zope2.View"
         class=".favourite.AddFavourite"
+        allowed_attributes="get_url add"
         />
 
     <browser:view
@@ -38,5 +39,3 @@
         />
 
 </configure>
-
-

--- a/ftw/dashboard/portlets/favourites/profiles/default/actions.xml
+++ b/ftw/dashboard/portlets/favourites/profiles/default/actions.xml
@@ -7,7 +7,7 @@
    <object name="addtofavourites" meta_type="CMF Action" i18n:domain="ftw.dashboard.portlets.favourites">
     <property name="title" i18n:translate="">Add to Favourites</property>
     <property name="description" i18n:translate="">Add to your Favourites.</property>
-    <property name="url_expr">string:${object_url}/@@add_to_favourites</property>
+    <property name="url_expr">python: here.restrictedTraverse('add_to_favourites').get_url()</property>
     <property name="icon_expr"> string:${globals_view/navigationRootUrl}/++resource++ftw.dashboard.portlets.favourites.resources/icon_add_favorite.gif</property>
     <property
        name="available_expr">python:(member is not None) and (portal.portal_membership.getHomeFolder() is not None)</property>

--- a/ftw/dashboard/portlets/favourites/profiles/default/metadata.xml
+++ b/ftw/dashboard/portlets/favourites/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>3001</version>
+  <version>3301</version>
 </metadata>

--- a/ftw/dashboard/portlets/favourites/tests/test_integration.py
+++ b/ftw/dashboard/portlets/favourites/tests/test_integration.py
@@ -34,8 +34,8 @@ class FavouriteTests(TestCase):
             "Folder", id="test_folder", title="Test Folder")
 
         # Adding
-        self.portal.restrictedTraverse('add_to_favourites')()
-        self.portal.test_folder.restrictedTraverse('add_to_favourites')()
+        self.portal.restrictedTraverse('add_to_favourites').add()
+        self.portal.test_folder.restrictedTraverse('add_to_favourites').add()
 
         content = self.home['Favourites'].listFolderContents()
 

--- a/ftw/dashboard/portlets/favourites/tests/test_portlet.py
+++ b/ftw/dashboard/portlets/favourites/tests/test_portlet.py
@@ -92,7 +92,7 @@ class TestRenderer(TestCase):
 
     def test_render(self):
 
-        self.portal.restrictedTraverse('add_to_favourites')()
+        self.portal.restrictedTraverse('add_to_favourites').add()
 
         r = self.renderer(assignment=favourites.Assignment())
         r = r.__of__(self.portal)

--- a/ftw/dashboard/portlets/favourites/tests/test_rename_favourite.py
+++ b/ftw/dashboard/portlets/favourites/tests/test_rename_favourite.py
@@ -15,7 +15,7 @@ class RenameFavouriteTests(TestCase):
 
     def test_rename_favourite(self):
         self.portal.invokeFactory("Folder", id="test_folder", title="Test Folder")
-        self.portal.test_folder.restrictedTraverse('add_to_favourites')()
+        self.portal.test_folder.restrictedTraverse('add_to_favourites').add()
 
         favourite = self.home['Favourites'].listFolderContents()[0]
 

--- a/ftw/dashboard/portlets/favourites/upgrades/configure.zcml
+++ b/ftw/dashboard/portlets/favourites/upgrades/configure.zcml
@@ -1,7 +1,10 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    xmlns:upgrade-step="http://namespaces.zope.org/ftw.upgrade"
     i18n_domain="ftw.dashboard.portlets.favourites">
+
+    <include package="ftw.upgrade" file="meta.zcml" />
 
     <!-- 1 -> 3001 -->
     <genericsetup:upgradeStep
@@ -11,6 +14,15 @@
         destination="3001"
         handler="ftw.dashboard.portlets.favourites.upgrades.to3001.ReplaceOldFavouritePortlets"
         profile="ftw.dashboard.portlets.favourites:default"
+        />
+
+    <!-- 3001 -> 3301 -->
+    <upgrade-step:importProfile
+        title="Made Add to Favourites action CSRF safe."
+        profile="ftw.dashboard.portlets.favourites:default"
+        source="3001"
+        destination="3301"
+        directory="profiles/3301"
         />
 
 </configure>

--- a/ftw/dashboard/portlets/favourites/upgrades/profiles/3301/actions.xml
+++ b/ftw/dashboard/portlets/favourites/upgrades/profiles/3301/actions.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<object name="portal_actions" meta_type="Plone Actions Tool"
+        xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+        i18n:domain="ftw.dashboard.portlets.favourites">
+
+  <object name="document_actions" meta_type="CMF Action Category">
+    <object name="addtofavourites" meta_type="CMF Action">
+      <property name="url_expr">python: here.restrictedTraverse('add_to_favourites').get_url()</property>
+    </object>
+  </object>
+
+</object>


### PR DESCRIPTION
Using plone.protect's authenticator token.

The AuthenticatorView provides the token method only since version 3.x. Therefore we had to extract the url generation to a separate view.

@jone please have a look ...