### PR TITLE
Rs 19 annotations favourites handler

### DIFF
--- a/ftw/dashboard/portlets/favourites/adapter.py
+++ b/ftw/dashboard/portlets/favourites/adapter.py
@@ -109,8 +109,15 @@ class DefaultFavouritesHandler(object):
         folder = self.get_favourites_container()
         catalog = getToolByName(folder, 'portal_catalog')
         brains = catalog(self.get_favourites_filter_query())
+        result = []
 
-        return brains
+        for brain in brains:
+            result.append({'id': brain.id,
+                           'title': brain.Title,
+                           'url': brain.getRemoteUrl.replace('resolveUid',
+                                                             'resolveuid')})
+
+        return result
 
     def get_favourites_filter_query(self):
         """Returns a catalog query to get favourites

--- a/ftw/dashboard/portlets/favourites/adapter.py
+++ b/ftw/dashboard/portlets/favourites/adapter.py
@@ -1,6 +1,8 @@
 from Products.CMFCore.utils import getToolByName
-from zope.component import getUtility
+from ftw.dashboard.portlets.favourites.interfaces import IFavouritesHandler
 from plone.registry.interfaces import IRegistry
+from zope.component import getUtility
+from zope.interface import implements
 
 
 class NoHomeFolderError(Exception):
@@ -16,13 +18,14 @@ class RegistryKeyError(Exception):
 class DefaultFavouritesHandler(object):
     """ Provides functions to add, remove or reorder favourites
     """
+    implements(IFavouritesHandler)
 
     def __init__(self, context, request):
         self.context = context
         self.request = request
         self.addable_types = ['Link']
 
-    def create_favourites_folder(self):
+    def create_favourites_container(self):
         """ Create the favourites folder
         """
         home_folder = self.get_home_folder()
@@ -42,7 +45,7 @@ class DefaultFavouritesHandler(object):
     def add_favourite(self, fav_id, title, remote_url):
         """ Add favourite to the favourites folder
         """
-        folder = self.get_favourites_folder()
+        folder = self.get_favourites_container()
         folder.invokeFactory('Link', id=fav_id)
         favourite = folder.get(fav_id)
 
@@ -54,7 +57,7 @@ class DefaultFavouritesHandler(object):
     def remove_favourite(self, fav_id):
         """ Remove favourite from th favourites folder
         """
-        folder = self.get_favourites_folder()
+        folder = self.get_favourites_container()
 
         try:
             folder.manage_delObjects(fav_id)
@@ -67,7 +70,7 @@ class DefaultFavouritesHandler(object):
     def rename_favourite(self, fav_id, title):
         """ Rename a favourite
         """
-        folder = self.get_favourites_folder()
+        folder = self.get_favourites_container()
         favourite = folder.get(fav_id)
         if favourite:
             favourite.setTitle(title)
@@ -78,7 +81,7 @@ class DefaultFavouritesHandler(object):
     def order_favourites(self, fav_ids=[]):
         """ Reorder the favourites in the given order of fav_ids
         """
-        folder = self.get_favourites_folder()
+        folder = self.get_favourites_container()
 
         for i, fav_id in enumerate(fav_ids):
             obj = folder.get(fav_id, '')
@@ -89,21 +92,21 @@ class DefaultFavouritesHandler(object):
             folder.moveObject(fav_id, i)
             obj.reindexObject(idxs=['getObjPositionInParent'])
 
-    def get_favourites_folder(self):
+    def get_favourites_container(self):
         """ Returns the folder the favourites are stored in
         """
         home_folder = self.get_home_folder()
         folder_name = self.get_favourite_folder_name()
 
         if not home_folder.get(folder_name):
-            self.create_favourites_folder()
+            self.create_favourites_container()
 
         return home_folder.get(folder_name)
 
     def get_favourites(self):
         """Return all favourites
         """
-        folder = self.get_favourites_folder()
+        folder = self.get_favourites_container()
         catalog = getToolByName(folder, 'portal_catalog')
         brains = catalog(self.get_favourites_filter_query())
 
@@ -112,7 +115,7 @@ class DefaultFavouritesHandler(object):
     def get_favourites_filter_query(self):
         """Returns a catalog query to get favourites
         """
-        folder = self.get_favourites_folder()
+        folder = self.get_favourites_container()
         query = {
             'path': {'query': '/'.join(folder.getPhysicalPath())},
             'portal_type': self.addable_types,
@@ -145,3 +148,34 @@ class DefaultFavouritesHandler(object):
                 "Can't access home folder. " \
                 "Please make sure you're owner of a homefolder")
         return home_folder
+
+
+class AnnotationStorageFavouritesHandler(object):
+    """ Annotation storage handler
+    """
+    implements(IFavouritesHandler)
+
+    def __init__(self, context, request):
+        self.context = context
+        self.request = request
+
+    def create_favourites_container(self):
+        pass
+
+    def add_favourite(self, fav_id, title, remote_url):
+        pass
+
+    def remove_favourite(self, fav_id):
+        pass
+
+    def rename_favourite(self, fav_id, title):
+        pass
+
+    def order_favourites(self, fav_ids=[]):
+        pass
+
+    def get_favourites_container(self):
+        pass
+
+    def get_favourites(self):
+        pass

--- a/ftw/dashboard/portlets/favourites/browser/favourite.py
+++ b/ftw/dashboard/portlets/favourites/browser/favourite.py
@@ -1,12 +1,13 @@
+import json
+import time
+
+from Products.CMFCore.utils import getToolByName
+from Products.Five.browser import BrowserView
 from ftw.dashboard.portlets.favourites import favouriteMessageFactory as _
 from ftw.dashboard.portlets.favourites.interfaces import IFavouritesHandler
 from plone.i18n.normalizer.interfaces import IIDNormalizer
-from Products.CMFCore.utils import getToolByName
-from Products.Five.browser import BrowserView
 from zope.component import getMultiAdapter
 from zope.component import getUtility
-import json
-import time
 
 
 # Try to get the plone.protect's createToken method, because it's only

--- a/ftw/dashboard/portlets/favourites/configure.zcml
+++ b/ftw/dashboard/portlets/favourites/configure.zcml
@@ -17,7 +17,11 @@
     <adapter
       for="* *"
       factory=".adapter.DefaultFavouritesHandler"
-      provides=".interfaces.IFavouritesHandler"
+     />
+
+     <adapter
+      for="* ftw.dashboard.portlets.favourites.interfaces.IFavouritesAnnotationStorageLayer"
+      factory=".adapter.AnnotationStorageFavouritesHandler"
      />
 
     <!-- Register the installation GenericSetup extension profile -->
@@ -25,6 +29,14 @@
       name="default"
       title="ftw.dashboard.portlets.favourites"
       directory="profiles/default"
+      description="ftw dashboard portlets favourites"
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      />
+
+    <genericsetup:registerProfile
+      name="annotationstorage"
+      title="ftw.dashboard.portlets.favourites with annotationstorage"
+      directory="profiles/annotationstorage"
       description="ftw dashboard portlets favourites"
       provides="Products.GenericSetup.interfaces.EXTENSION"
       />

--- a/ftw/dashboard/portlets/favourites/configure.zcml
+++ b/ftw/dashboard/portlets/favourites/configure.zcml
@@ -35,7 +35,7 @@
 
     <genericsetup:registerProfile
       name="annotationstorage"
-      title="ftw.dashboard.portlets.favourites with annotationstorage"
+      title="ftw.dashboard.portlets.favourites using annotationstorage"
       directory="profiles/annotationstorage"
       description="ftw dashboard portlets favourites"
       provides="Products.GenericSetup.interfaces.EXTENSION"

--- a/ftw/dashboard/portlets/favourites/interfaces.py
+++ b/ftw/dashboard/portlets/favourites/interfaces.py
@@ -3,45 +3,38 @@ from zope.interface import Interface
 
 class IFavouritesHandler(Interface):
     """The IFavouritesHandler adapter provides functionality to create
-    favourites folder and add or remove
+    favourites container and add or remove
     """
 
-    def create_favourites_folder(self):
-        """ Create the favourites folder
+    def create_favourites_container():
+        """ Create the favourites container
         """
 
-    def add_favourite(self, fav_id, title, remote_url):
-        """ Add favourite to the favourites folder
+    def add_favourite(fav_id, title, remote_url):
+        """ Add favourite to the favourites container
         """
 
-    def remove_favourite(self, fav_id):
-        """ Remove favourite from th favourites folder
+    def remove_favourite(fav_id):
+        """ Remove favourite from th favourites container
         """
 
-    def rename_favourite(self, fav_id, title):
+    def rename_favourite(fav_id, title):
         """ Rename a favourite
         """
 
-    def order_favourites(self, fav_ids=[]):
+    def order_favourites(fav_ids=[]):
         """ Reorder the favourites in the given order of fav_ids
         """
 
-    def get_favourites_folder(self):
-        """ Returns the folder the favourites are stored in
+    def get_favourites_container():
+        """ Returns the container the favourites are stored in
         """
 
-    def get_favourites(self):
+    def get_favourites():
         """Return all favourites
         """
 
-    def get_favourites_filter_query(self):
-        """Returns a catalog query to get favourites
-        """
 
-    def get_favourite_folder_name(self):
-        """ Return the foldername where we want to store favourites
-        """
-
-    def get_home_folder(self):
-        """ Return the homefolder of the logged-in user.
-        """
+class IFavouritesAnnotationStorageLayer(Interface):
+    """ Browser layer for annotation storage
+    """

--- a/ftw/dashboard/portlets/favourites/portlets/favourites.py
+++ b/ftw/dashboard/portlets/favourites/portlets/favourites.py
@@ -45,7 +45,7 @@ class Renderer(base.Renderer):
 
     def items(self):
         handler = getMultiAdapter((self.context, self.request),
-            IFavouritesHandler)
+                                  IFavouritesHandler)
 
         return handler.get_favourites()
 

--- a/ftw/dashboard/portlets/favourites/portlets/templates/favourites.pt
+++ b/ftw/dashboard/portlets/favourites/portlets/templates/favourites.pt
@@ -14,13 +14,11 @@
             <tal:items tal:repeat="item items">
 
                 <dd tal:define="oddrow repeat/item/odd;"
-                    tal:attributes="class python:oddrow and  'favourite-item even' or 'favourite-item odd';
-                                    id string:${item/id}">
+                    tal:attributes="class python:oddrow and  'favourite-item even' or 'favourite-item odd'; id string:${item/id}">
                     <span class="title">
                         <a href=""
-                           tal:attributes="href python: item.getRemoteUrl.replace('resolveUid', 'resolveuid');
-                                           title item/Title;">
-                            <tal:title content="item/Title" />
+                           tal:attributes="href item/url; title item/title;">
+                            <tal:title content="item/title" />
                         </a>
                     </span>
                 </dd>

--- a/ftw/dashboard/portlets/favourites/profiles/annotationstorage/actions.xml
+++ b/ftw/dashboard/portlets/favourites/profiles/annotationstorage/actions.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<object name="portal_actions" meta_type="Plone Actions Tool"
+        xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+        i18n:domain="ftw.dashboard.portlets.favourites">
+
+  <object name="document_actions" meta_type="CMF Action Category">
+   <object name="addtofavourites" meta_type="CMF Action" remove="True" i18n:domain="ftw.dashboard.portlets.favourites" />
+   <object name="addtofavourites" meta_type="CMF Action" i18n:domain="ftw.dashboard.portlets.favourites">
+    <property name="title" i18n:translate="">Add to Favourites</property>
+    <property name="description" i18n:translate="">Add to your Favourites.</property>
+    <property name="url_expr">python: here.restrictedTraverse('add_to_favourites').get_url()</property>
+    <property name="icon_expr"> string:${globals_view/navigationRootUrl}/++resource++ftw.dashboard.portlets.favourites.resources/icon_add_favorite.gif</property>
+    <property name="available_expr">python:(member is not None)</property>
+    <property name="permissions">
+     <element value="View"/>
+    </property>
+    <property name="visible">True</property>
+   </object>
+  </object>
+
+</object>

--- a/ftw/dashboard/portlets/favourites/profiles/annotationstorage/browserlayer.xml
+++ b/ftw/dashboard/portlets/favourites/profiles/annotationstorage/browserlayer.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<layers>
+
+    <layer name="ftw.dashboard.portlets.favourites.annotationstorage"
+           interface="ftw.dashboard.portlets.favourites.interfaces.IFavouritesAnnotationStorageLayer" />
+
+</layers>

--- a/ftw/dashboard/portlets/favourites/testing.py
+++ b/ftw/dashboard/portlets/favourites/testing.py
@@ -1,13 +1,17 @@
+from ftw.builder.testing import BUILDER_LAYER
+from ftw.builder.testing import functional_session_factory
+from ftw.builder.testing import set_builder_session_factory
 from plone.app.testing import applyProfile
+from plone.app.testing import FunctionalTesting
 from plone.app.testing import IntegrationTesting
-from plone.app.testing import PloneSandboxLayer
 from plone.app.testing import PLONE_FIXTURE
-from plone.testing.z2 import installProduct
-from zope.configuration import xmlconfig
-from plone.app.testing import TEST_USER_ID
+from plone.app.testing import PloneSandboxLayer
 from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
 from plone.testing import Layer
 from plone.testing import zca
+from plone.testing.z2 import installProduct
+from zope.configuration import xmlconfig
 
 
 class FavouritesZCMLLayer(Layer):
@@ -30,7 +34,7 @@ FAVOURITES_ZCML_LAYER = FavouritesZCMLLayer()
 
 class FavouritesPloneLayer(PloneSandboxLayer):
 
-    defaultBases = (PLONE_FIXTURE, )
+    defaultBases = (PLONE_FIXTURE, BUILDER_LAYER)
 
     def setUpZope(self, app, configurationContext):
         # Load ZCML
@@ -54,5 +58,21 @@ class FavouritesPloneLayer(PloneSandboxLayer):
 
 FavouritesPloneFixture = FavouritesPloneLayer()
 FAVOURITES_PLONE_LAYER = IntegrationTesting(
-    bases=(FavouritesPloneFixture, ),
+    bases=(
+        FavouritesPloneFixture,
+        set_builder_session_factory(functional_session_factory)),
     name="ftw.dashboard.portlets.favourites:Integration")
+
+
+class FavouritesAnnotationStorageLayer(FavouritesPloneLayer):
+
+    def setUpPloneSite(self, portal):
+        super(FavouritesAnnotationStorageLayer, self).setUpPloneSite(portal)
+        applyProfile(portal, 'ftw.dashboard.portlets.favourites:annotationstorage')
+
+FavouritesAnnotationStorageFixture = FavouritesAnnotationStorageLayer()
+FAVOURITES_ANNOTATION_STORAGE_LAYER = FunctionalTesting(
+    bases=(
+        FavouritesAnnotationStorageFixture,
+        set_builder_session_factory(functional_session_factory)),
+    name="ftw.dashboard.portlets.favourites:functional annotationstorage")

--- a/ftw/dashboard/portlets/favourites/tests/__init__.py
+++ b/ftw/dashboard/portlets/favourites/tests/__init__.py
@@ -1,0 +1,21 @@
+from ftw.dashboard.portlets.favourites.testing import FAVOURITES_PLONE_LAYER
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from unittest2 import TestCase
+from zope.event import notify
+from zope.traversing.interfaces import BeforeTraverseEvent
+import transaction
+
+
+class FunctionalTestCase(TestCase):
+    layer = FAVOURITES_PLONE_LAYER
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        self.request = self.layer['request']
+
+        notify(BeforeTraverseEvent(self.portal, self.portal.REQUEST))
+
+    def grant(self, *roles):
+        setRoles(self.portal, TEST_USER_ID, list(roles))
+        transaction.commit()

--- a/ftw/dashboard/portlets/favourites/tests/test_handler.py
+++ b/ftw/dashboard/portlets/favourites/tests/test_handler.py
@@ -1,8 +1,10 @@
+# coding=UTF-8
 from ftw.dashboard.portlets.favourites.adapter import AnnotationStorageFavouritesHandler
 from ftw.dashboard.portlets.favourites.adapter import DefaultFavouritesHandler
 from ftw.dashboard.portlets.favourites.interfaces import IFavouritesHandler
 from ftw.dashboard.portlets.favourites.testing import FAVOURITES_ANNOTATION_STORAGE_LAYER
 from ftw.dashboard.portlets.favourites.tests import FunctionalTestCase
+from persistent.dict import PersistentDict
 from zope.component import getMultiAdapter
 
 
@@ -18,8 +20,72 @@ class TestFavouriteDefaultHandler(FunctionalTestCase):
 class TestAnnotationHandler(FunctionalTestCase):
     layer = FAVOURITES_ANNOTATION_STORAGE_LAYER
 
-    def test_lookup_adapter_returns_annotation_handler(self):
-        handler = getMultiAdapter(
+    def setUp(self):
+        super(TestAnnotationHandler, self).setUp()
+        self.handler = getMultiAdapter(
             (self.portal, self.request),
             IFavouritesHandler)
-        self.assertIsInstance(handler, AnnotationStorageFavouritesHandler)
+
+    def test_lookup_adapter_returns_annotation_handler(self):
+        self.assertIsInstance(self.handler, AnnotationStorageFavouritesHandler)
+
+    def test_favourites_container_gets_created(self):
+        self.handler.create_favourites_container()
+
+        self.assertEqual(
+            [('test_user_1_', PersistentDict()), ],
+            [item for item in self.handler.storage.iteritems()])
+
+    def test_favourites_container_gets_returned(self):
+        self.assertEqual(
+            PersistentDict(), self.handler.get_favourites_container())
+
+    def test_favourite_gets_added(self):
+        self.handler.add_favourite("id_1", "jamesö", "url/bond")
+
+        self.assertEqual(
+            PersistentDict(
+                id_1=PersistentDict(title="jamesö", url="url/bond", pos=-1)),
+            self.handler.get_favourites_container())
+
+    def test_get_favourite_returns_items_as_list(self):
+        self.handler.add_favourite("id_1", "james", "url/bond")
+
+        self.assertEqual(
+            [
+                dict(id="id_1", title="james", url="url/bond"),
+            ],
+            self.handler.get_favourites())
+
+    def test_order_favourites_sorts_correctly(self):
+        self.handler.add_favourite("id_1", "james", "url/bond")
+        self.handler.add_favourite("id_2", "chuck", "url/norris")
+        self.handler.add_favourite("id_3", "tony", "url/stark")
+
+        self.handler.order_favourites(['id_3', 'id_2', 'id_1'])
+
+        self.assertEqual(
+            [
+                dict(id="id_3", title="tony", url="url/stark"),
+                dict(id="id_2", title="chuck", url="url/norris"),
+                dict(id="id_1", title="james", url="url/bond")
+            ],
+            self.handler.get_favourites())
+
+    def test_favourites_get_renamed_correctly(self):
+        self.handler.add_favourite("id_1", "james", "url/bond")
+
+        self.handler.rename_favourite("id_1", "michael")
+
+        self.assertEqual(
+            "michael",
+            self.handler.get_favourites_container()["id_1"]["title"])
+
+    def test_favourites_get_deleted_correctly(self):
+        self.handler.add_favourite("id_1", "james", "url/bond")
+
+        self.handler.remove_favourite("id_1")
+
+        self.assertEqual(
+            [],
+            self.handler.get_favourites())

--- a/ftw/dashboard/portlets/favourites/tests/test_handler.py
+++ b/ftw/dashboard/portlets/favourites/tests/test_handler.py
@@ -1,0 +1,25 @@
+from ftw.dashboard.portlets.favourites.adapter import AnnotationStorageFavouritesHandler
+from ftw.dashboard.portlets.favourites.adapter import DefaultFavouritesHandler
+from ftw.dashboard.portlets.favourites.interfaces import IFavouritesHandler
+from ftw.dashboard.portlets.favourites.testing import FAVOURITES_ANNOTATION_STORAGE_LAYER
+from ftw.dashboard.portlets.favourites.tests import FunctionalTestCase
+from zope.component import getMultiAdapter
+
+
+class TestFavouriteDefaultHandler(FunctionalTestCase):
+
+    def test_lookup_adapter_returns_default_handler(self):
+        handler = getMultiAdapter(
+            (self.portal, self.request),
+            IFavouritesHandler)
+        self.assertIsInstance(handler, DefaultFavouritesHandler)
+
+
+class TestAnnotationHandler(FunctionalTestCase):
+    layer = FAVOURITES_ANNOTATION_STORAGE_LAYER
+
+    def test_lookup_adapter_returns_annotation_handler(self):
+        handler = getMultiAdapter(
+            (self.portal, self.request),
+            IFavouritesHandler)
+        self.assertIsInstance(handler, AnnotationStorageFavouritesHandler)

--- a/ftw/dashboard/portlets/favourites/tests/test_interfaces.py
+++ b/ftw/dashboard/portlets/favourites/tests/test_interfaces.py
@@ -1,0 +1,14 @@
+from ftw.dashboard.portlets.favourites.adapter import AnnotationStorageFavouritesHandler
+from ftw.dashboard.portlets.favourites.adapter import DefaultFavouritesHandler
+from ftw.dashboard.portlets.favourites.interfaces import IFavouritesHandler
+from unittest2 import TestCase
+from zope.interface.verify import verifyClass
+
+
+class TestVerifyInterfaces(TestCase):
+
+    def test_favourites_handler(self):
+        verifyClass(IFavouritesHandler, DefaultFavouritesHandler)
+
+    def test_favourites_annotation_storage(self):
+        verifyClass(IFavouritesHandler, AnnotationStorageFavouritesHandler)

--- a/ftw/dashboard/portlets/favourites/tests/test_unit_defaultfavouriteshandler.py
+++ b/ftw/dashboard/portlets/favourites/tests/test_unit_defaultfavouriteshandler.py
@@ -24,7 +24,7 @@ class RemoveFavourite(MockTestCase):
 
         self.handler = self.mocker.patch(
             DefaultFavouritesHandler(self.context, self.request))
-        self.expect(self.handler.get_favourites_folder()).result(self.folder)
+        self.expect(self.handler.get_favourites_container()).result(self.folder)
 
     def test_valid_id(self):
 
@@ -70,7 +70,7 @@ class OrderFavourites(MockTestCase):
 
         self.handler = self.mocker.patch(
             DefaultFavouritesHandler(self.context, self.request))
-        self.expect(self.handler.get_favourites_folder()).result(self.folder)
+        self.expect(self.handler.get_favourites_container()).result(self.folder)
 
     def test_all_valid(self):
 

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(name='ftw.dashboard.portlets.favourites',
         'setuptools',
         'ftw.dashboard.dragndrop',
         'ftw.upgrade',
+        'plone.api'
         ],
       tests_require=tests_require,
       extras_require=dict(tests=tests_require),

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,8 @@ mainainter = 'Philipp Gross'
 tests_require = [
     'plone.app.testing',
     'ftw.testing',
+    'ftw.builder',
+    'ftw.testbrowser',
     ]
 
 setup(name='ftw.dashboard.portlets.favourites',


### PR DESCRIPTION
Refactors the favourites portlet to use annotations instead of a user home-folder.

If a user adds a favourite, the item will be added to a persistendDict on the plone root annotations.


closes #19 